### PR TITLE
Add Postman OAuth2 testing configuration (local only)

### DIFF
--- a/POSTMAN_OAUTH_SETUP.md
+++ b/POSTMAN_OAUTH_SETUP.md
@@ -1,0 +1,215 @@
+# Postman OAuth2 Authentication Setup Guide
+
+This guide explains how to test OAuth2 authentication using Postman with your Spring Boot application.
+
+## Prerequisites
+
+1. **Postman** installed (download from https://www.postman.com/downloads/)
+2. **GitHub OAuth App** or **Google OAuth Client** credentials
+3. Application running locally on `http://localhost:8080`
+
+## Setup Instructions
+
+### Step 1: Start Application with Postman Profile
+
+Run the application with the `postman` profile enabled:
+
+```bash
+# Windows (PowerShell)
+.\gradlew.bat bootRun --args='--spring.profiles.active=postman'
+
+# Or set environment variable
+$env:SPRING_PROFILES_ACTIVE="postman"
+.\gradlew.bat bootRun
+```
+
+### Step 2: Configure OAuth2 Credentials
+
+Create a `.env` file or set environment variables with your OAuth2 credentials:
+
+```properties
+# GitHub OAuth2
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# Google OAuth2
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+```
+
+**To create GitHub OAuth App:**
+1. Go to https://github.com/settings/developers
+2. Click "New OAuth App"
+3. Set Authorization callback URL to: `http://localhost:8080/login/oauth2/code/github`
+4. Copy Client ID and Client Secret
+
+**To create Google OAuth Client:**
+1. Go to https://console.cloud.google.com/apis/credentials
+2. Create OAuth 2.0 Client ID
+3. Set Authorized redirect URI to: `http://localhost:8080/login/oauth2/code/google`
+4. Copy Client ID and Client Secret
+
+### Step 3: Configure Postman
+
+#### Option A: Using Postman's OAuth 2.0 Authorization
+
+1. **Open Postman** and create a new request
+2. Go to the **Authorization** tab
+3. Select **OAuth 2.0** from the Type dropdown
+4. Click **Get New Access Token**
+5. Configure:
+   
+   **For GitHub:**
+   - Token Name: `GitHub OAuth`
+   - Grant Type: `Authorization Code`
+   - Callback URL: `http://localhost:8080/login/oauth2/code/github`
+   - Auth URL: `https://github.com/login/oauth/authorize`
+   - Access Token URL: `https://github.com/login/oauth/access_token`
+   - Client ID: `<your-github-client-id>`
+   - Client Secret: `<your-github-client-secret>`
+   - Scope: `read:user user:email`
+
+   **For Google:**
+   - Token Name: `Google OAuth`
+   - Grant Type: `Authorization Code`
+   - Callback URL: `http://localhost:8080/login/oauth2/code/google`
+   - Auth URL: `https://accounts.google.com/o/oauth2/v2/auth`
+   - Access Token URL: `https://oauth2.googleapis.com/token`
+   - Client ID: `<your-google-client-id>`
+   - Client Secret: `<your-google-client-secret>`
+   - Scope: `profile email`
+
+6. Click **Request Token**
+7. Complete OAuth flow in browser
+8. Use the token in your requests
+
+#### Option B: Browser-Based Authentication (Simpler)
+
+1. Open browser and go to `http://localhost:8080/login`
+2. Click "Login with GitHub" or "Login with Google"
+3. Complete OAuth flow
+4. After successful login, open browser DevTools (F12)
+5. Go to Application/Storage > Cookies > `http://localhost:8080`
+6. Copy the `JSESSIONID` cookie value
+7. In Postman, add a cookie header:
+   ```
+   Cookie: JSESSIONID=<your-session-id>
+   ```
+
+### Step 4: Test Authenticated Endpoints
+
+Create requests in Postman to test your API:
+
+#### Test Authentication Status
+```
+GET http://localhost:8080/api/auth/status
+```
+
+#### Get Current User Info
+```
+GET http://localhost:8080/api/user
+```
+
+#### Get Games (Authenticated)
+```
+GET http://localhost:8080/api/games/all
+```
+
+#### Get Teams (Authenticated)
+```
+GET http://localhost:8080/api/teams/all
+```
+
+## Available Endpoints
+
+### Public Endpoints (No Auth Required)
+- `GET /` - Home page
+- `GET /login` - Login page
+- `GET /api/public/status` - Public status check
+
+### Protected Endpoints (Auth Required)
+- `GET /api/auth/status` - Check authentication status
+- `GET /api/auth/success` - OAuth success callback info
+- `GET /api/user` - Get current user details
+- `GET /api/games/all` - Get all games
+- `GET /api/games/team/{id}` - Get games by team
+- `GET /api/teams/all` - Get all teams
+- `GET /dashboard` - User dashboard (HTML)
+- `GET /profile` - User profile (HTML)
+
+## Troubleshooting
+
+### Issue: "Not authenticated" responses
+- **Solution**: Ensure you're logged in via browser first and using the correct JSESSIONID cookie
+- Or configure OAuth 2.0 properly in Postman's Authorization tab
+
+### Issue: CSRF token errors
+- **Solution**: CSRF is disabled in postman profile. Ensure you're running with `--spring.profiles.active=postman`
+
+### Issue: OAuth callback not working
+- **Solution**: 
+  - Verify redirect URIs match exactly in OAuth provider settings
+  - Check that application is running on `http://localhost:8080`
+  - Ensure OAuth credentials are set correctly in environment variables
+
+### Issue: CORS errors
+- **Solution**: The postman profile allows requests from `*.postman.com` and `localhost:8080`
+
+## Security Notes
+
+⚠️ **Important**: The `postman` profile is for **local testing only**!
+
+- CSRF protection is disabled
+- Debug logging is enabled
+- Uses H2 in-memory database
+- Never use this profile in production
+
+For production testing, use the `prod` profile with proper security configurations.
+
+## Postman Collection
+
+You can import this collection to quickly test all endpoints:
+
+```json
+{
+  "info": {
+    "name": "NBA Games API - OAuth2",
+    "description": "Test OAuth2 authentication and API endpoints"
+  },
+  "auth": {
+    "type": "oauth2"
+  },
+  "item": [
+    {
+      "name": "Auth Status",
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:8080/api/auth/status"
+      }
+    },
+    {
+      "name": "Get User",
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:8080/api/user"
+      }
+    },
+    {
+      "name": "Get All Games",
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:8080/api/games/all"
+      }
+    },
+    {
+      "name": "Get All Teams",
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:8080/api/teams/all"
+      }
+    }
+  ]
+}
+```
+
+Save this as `NBA_Games_OAuth2.postman_collection.json` and import into Postman.

--- a/src/main/groovy/com/example/demo/Project2BackendApplication.groovy
+++ b/src/main/groovy/com/example/demo/Project2BackendApplication.groovy
@@ -2,11 +2,10 @@ package com.example.demo
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
 import org.springframework.context.annotation.ComponentScan
 
-// Exclude OAuth2 for local development - will be enabled in production via application-prod.properties
-@SpringBootApplication(exclude = [OAuth2ClientAutoConfiguration])
+// OAuth2 is enabled for 'postman' and 'prod' profiles, disabled for default local dev
+@SpringBootApplication
 //just to find the package, without this it cant find the DataLoader class
 @ComponentScan(basePackages = ["com.example.demo", "main.groovy.com.example.demo.loader"])
 class Project2BackendApplication {

--- a/src/main/groovy/com/example/demo/config/PostmanSecurityConfig.groovy
+++ b/src/main/groovy/com/example/demo/config/PostmanSecurityConfig.groovy
@@ -1,0 +1,70 @@
+package com.example.demo.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+@EnableWebSecurity
+@Profile("postman")
+class PostmanSecurityConfig {
+
+    @Bean
+    SecurityFilterChain postmanFilterChain(HttpSecurity http) throws Exception {
+        http
+            .cors { cors ->
+                cors.configurationSource(corsConfigurationSource())
+            }
+            .csrf { csrf ->
+                csrf.disable() // Disable CSRF for Postman testing
+            }
+            .authorizeHttpRequests { authz ->
+                authz
+                    // Public endpoints
+                    .requestMatchers("/", "/login", "/error", "/h2-console/**").permitAll()
+                    // API endpoints require authentication
+                    .requestMatchers("/api/**").authenticated()
+                    // OAuth2 endpoints
+                    .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .oauth2Login { oauth2 ->
+                oauth2
+                    .loginPage("/login")
+                    .defaultSuccessUrl("/api/auth/success", true)
+                    .failureUrl("/login?error=true")
+            }
+            .logout { logout ->
+                logout
+                    .logoutUrl("/logout")
+                    .logoutSuccessUrl("/?logout=success")
+                    .invalidateHttpSession(true)
+                    .clearAuthentication(true)
+                    .deleteCookies("JSESSIONID")
+            }
+            .headers { headers ->
+                headers.frameOptions { frame -> frame.sameOrigin() } // For H2 console
+            }
+
+        return http.build()
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration()
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:8080", "https://*.postman.com"))
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"))
+        configuration.setAllowedHeaders(Arrays.asList("*"))
+        configuration.setAllowCredentials(true)
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
+}

--- a/src/main/groovy/com/example/demo/config/SecurityConfig.groovy
+++ b/src/main/groovy/com/example/demo/config/SecurityConfig.groovy
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.core.Authentication
@@ -21,6 +22,7 @@ import java.util.Arrays
 
 @Configuration
 @EnableWebSecurity
+@Profile("!postman") // Don't load this config when using postman profile
 class SecurityConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class)

--- a/src/main/groovy/com/example/demo/controller/AuthController.groovy
+++ b/src/main/groovy/com/example/demo/controller/AuthController.groovy
@@ -92,6 +92,38 @@ class AuthRestController {
         ]
     }
 
+    @GetMapping("/api/auth/success")
+    Map<String, Object> loginSuccess(@AuthenticationPrincipal OAuth2User principal) {
+        if (principal == null) {
+            return [
+                authenticated: false,
+                message: "Not authenticated"
+            ]
+        }
+        
+        return [
+            authenticated: true,
+            message: "Successfully authenticated",
+            user: [
+                name: principal.getAttribute("name") ?: principal.getAttribute("login"),
+                email: principal.getAttribute("email"),
+                avatar: principal.getAttribute("avatar_url") ?: principal.getAttribute("picture"),
+                provider: getProvider(principal)
+            ]
+        ]
+    }
+
+    @GetMapping("/api/auth/status")
+    Map<String, Object> authStatus(@AuthenticationPrincipal OAuth2User principal) {
+        boolean isAuthenticated = principal != null
+        
+        return [
+            authenticated: isAuthenticated,
+            provider: isAuthenticated ? getProvider(principal) : null,
+            message: isAuthenticated ? "User is authenticated" : "User is not authenticated"
+        ]
+    }
+
     @GetMapping("/api/public/status")
     Map<String, Object> publicStatus() {
         return [

--- a/src/main/resources/application-postman.properties
+++ b/src/main/resources/application-postman.properties
@@ -1,0 +1,42 @@
+# Postman Testing Profile
+# This profile enables OAuth2 for API testing with Postman
+
+# H2 Database for local testing
+spring.datasource.url=jdbc:h2:file:./data/nba_games_db
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+# H2 Console
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# Server Configuration
+server.port=8080
+
+# Application base URL
+app.base-url=http://localhost:8080
+
+# =================================
+# OAUTH2 FOR POSTMAN TESTING
+# =================================
+# GitHub OAuth2 Provider
+spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:your-github-client-id}
+spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:your-github-client-secret}
+spring.security.oauth2.client.registration.github.scope=read:user,user:email
+spring.security.oauth2.client.registration.github.redirect-uri=http://localhost:8080/login/oauth2/code/github
+
+# Google OAuth2 Provider
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:your-google-client-id}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+
+# Logging
+logging.level.root=INFO
+logging.level.com.example.demo=DEBUG
+logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.security.oauth2=DEBUG

--- a/src/main/resources/application-postman.properties
+++ b/src/main/resources/application-postman.properties
@@ -1,6 +1,9 @@
 # Postman Testing Profile
 # This profile enables OAuth2 for API testing with Postman
 
+# Override default OAuth2 exclusion - enable it for postman profile
+spring.autoconfigure.exclude=
+
 # H2 Database for local testing
 spring.datasource.url=jdbc:h2:file:./data/nba_games_db
 spring.datasource.driverClassName=org.h2.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,6 +45,9 @@ server.servlet.session.timeout=30m
 # Base URL Configuration
 app.base-url=${APP_BASE_URL:http://localhost:8080}
 
+# Exclude OAuth2 autoconfiguration for default local development
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+
 # =================================
 # OAUTH2 CLIENT CONFIGURATION
 # =================================

--- a/start-postman-with-oauth.bat
+++ b/start-postman-with-oauth.bat
@@ -1,0 +1,36 @@
+@echo off
+echo ================================================
+echo Starting NBA Games API with OAuth2 (from .env)
+echo ================================================
+echo.
+
+REM Load environment variables from .env file
+if exist .env (
+    echo Loading OAuth2 credentials from .env file...
+    echo.
+    for /F "usebackq tokens=1,2 delims==" %%A in (".env") do (
+        set "%%A=%%B"
+    )
+    
+    echo GitHub Client ID: %GITHUB_CLIENT_ID%
+    echo Google Client ID: %GOOGLE_CLIENT_ID%
+    echo.
+) else (
+    echo ERROR: .env file not found!
+    echo Please create a .env file with your OAuth2 credentials.
+    echo.
+    pause
+    exit /b 1
+)
+
+echo Starting application with postman profile...
+echo Application will start on: http://localhost:8080
+echo.
+echo OAuth2 login pages:
+echo - GitHub: http://localhost:8080/oauth2/authorization/github
+echo - Google: http://localhost:8080/oauth2/authorization/google
+echo.
+echo ================================================
+echo.
+
+gradlew.bat bootRun --args="--spring.profiles.active=postman"

--- a/start-postman.bat
+++ b/start-postman.bat
@@ -1,0 +1,36 @@
+@echo off
+echo ================================================
+echo Starting NBA Games API with Postman OAuth2
+echo ================================================
+echo.
+echo This will start the application with OAuth2 enabled
+echo for testing with Postman.
+echo.
+echo Make sure you have set your OAuth2 credentials:
+echo - GITHUB_CLIENT_ID
+echo - GITHUB_CLIENT_SECRET
+echo - GOOGLE_CLIENT_ID
+echo - GOOGLE_CLIENT_SECRET
+echo.
+echo Application will start on: http://localhost:8080
+echo.
+echo ================================================
+echo.
+
+REM Check if OAuth credentials are set
+if "%GITHUB_CLIENT_ID%"=="" (
+    echo WARNING: GITHUB_CLIENT_ID not set!
+    echo Please set your GitHub OAuth credentials.
+    echo.
+)
+
+if "%GOOGLE_CLIENT_ID%"=="" (
+    echo WARNING: GOOGLE_CLIENT_ID not set!
+    echo Please set your Google OAuth credentials.
+    echo.
+)
+
+echo Starting application with postman profile...
+echo.
+
+gradlew.bat bootRun --args="--spring.profiles.active=postman"


### PR DESCRIPTION
## Postman OAuth2 Testing Setup

This PR adds configuration to test OAuth2 authentication with Postman on your local machine.

### What's Added:

**New Files:**
- `application-postman.properties` - Spring profile for Postman testing
- `PostmanSecurityConfig.groovy` - Security config with OAuth2 enabled, CSRF disabled
- `start-postman-with-oauth.bat` - Script to load .env and start with OAuth credentials
- `POSTMAN_OAUTH_SETUP.md` - Complete setup guide
- `.env` - OAuth2 credentials (gitignored, created locally from Heroku config)

**Modified Files:**
- `SecurityConfig.groovy` - Added @Profile("!postman") to prevent conflicts
- `Project2BackendApplication.groovy` - Removed OAuth2 exclusion (now conditional)
- `application.properties` - Exclude OAuth2 by default
- `AuthController.groovy` - Added /api/auth/success and /api/auth/status endpoints

### How to Use:

**For Local Postman Testing:**
1. Run `.\start-postman-with-oauth.bat` (loads OAuth credentials from .env)
2. App starts with OAuth2 enabled on localhost:8080
3. Follow POSTMAN_OAUTH_SETUP.md guide

**For Regular Local Dev:**
- OAuth2 remains disabled by default
- Use existing workflow (.\gradlew bootRun)

**For Production/Heroku:**
- Not affected - continues using prod profile
- OAuth2 works as before

### Important Notes:

- This is for LOCAL testing only - not for Heroku deployment
- .env file contains OAuth credentials and is gitignored
- Postman profile only activates when explicitly specified
- Does NOT affect existing test coverage or production behavior

### Testing Done:

- App starts successfully with postman profile
- OAuth2 security configuration loads correctly  
- Protected endpoints redirect to login
- Public endpoints remain accessible
- No conflicts with existing profiles